### PR TITLE
Local Validators

### DIFF
--- a/format_checkers_test.go
+++ b/format_checkers_test.go
@@ -1,9 +1,20 @@
 package gojsonschema
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
+
+type mockFormatChecker struct {
+	mock.Mock
+}
+
+func (c *mockFormatChecker) IsFormat(input interface{}) bool {
+	args := c.Called(input)
+	return args.Bool(0)
+}
 
 func TestUUIDFormatCheckerIsFormat(t *testing.T) {
 	checker := UUIDFormatChecker{}

--- a/schema.go
+++ b/schema.go
@@ -51,7 +51,9 @@ func NewSchema(l JSONLoader) (*Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.formatCheckers = new(FormatCheckerChain)
+	s.formatCheckers = &FormatCheckerChain{
+		formatters: make(map[string]FormatChecker),
+	}
 	return s, nil
 }
 

--- a/validation.go
+++ b/validation.go
@@ -911,7 +911,7 @@ func globalFmtCheck(currentSubSchema *subSchema, value interface{}, result *Resu
 }
 
 func applyFmtCheck(checkers *FormatCheckerChain, currentSubSchema *subSchema, value interface{}, result *Result, context *JsonContext) {
-	if checkers.IsFormat(currentSubSchema.format, value) {
+	if !checkers.IsFormat(currentSubSchema.format, value) {
 		result.addInternalError(
 			new(DoesNotMatchFormatError),
 			context,


### PR DESCRIPTION
So another issue with the 3rd party library is that it utilizes a global `FormatCheckers` for the entire JSONSchema lib.

See example code snippet below:

```go
	// FormatChecker is the interface all formatters added to FormatCheckerChain must implement
	FormatChecker interface {
		// IsFormat checks if input has the correct format and type
		IsFormat(input interface{}) bool
	}
```

This is particularly problematic given our case because we are allowing users to make their own custom JSON schemas and maybe each user want their own custom validation on the same format. Also, it would inextricably cause all schemas to have to use the same validators and potentially affect or override.

## Solution

For now, each `Schema` entity will have its own `FormatCheckerChain`. And because of their code, I had to essentially pass this `Schema` ptr to all their recursive functions... See below:

```go
// Walker function to validate the json recursively against the subSchema
func (v *subSchema) validateRecursive(topSchema *Schema, currentSubSchema *subSchema, currentNode interface{}, result *Result, context *JsonContext) {
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fetchrobotics/gojsonschema/2)
<!-- Reviewable:end -->
