### PR TITLE
Fix jsonschema_test

### DIFF
--- a/schemaLoader.go
+++ b/schemaLoader.go
@@ -157,6 +157,9 @@ func (sl *SchemaLoader) Compile(rootSchema JSONLoader) (*Schema, error) {
 	d.pool.jsonLoaderFactory = rootSchema.LoaderFactory()
 	d.documentReference = ref
 	d.referencePool = newSchemaReferencePool()
+	d.formatCheckers = &FormatCheckerChain{
+		formatters: make(map[string]FormatCheckerWithError, 0),
+	}
 
 	var doc interface{}
 	if ref.String() != "" {


### PR DESCRIPTION
Problem is that `compile` method also needs to be updated. Else, will cause errors in `jsonschema_test.go`